### PR TITLE
Fix link to Yosys project

### DIFF
--- a/index.md
+++ b/index.md
@@ -96,7 +96,7 @@ This project provides packages for:
     * [package repository][nextpnr-pkg];
     * PyPI packages: [<img src="https://img.shields.io/pypi/v/yowasp-nextpnr-ice40?label=yowasp-nextpnr-ice40&color=green" alt="yowasp-nextpnr-ice40" class="badge">](https://pypi.org/project/yowasp-nextpnr-ice40/), [<img src="https://img.shields.io/pypi/v/yowasp-nextpnr-ecp5?label=yowasp-nextpnr-ecp5&color=green" alt="yowasp-nextpnr-ecp5" class="badge">](https://pypi.org/project/yowasp-nextpnr-ecp5/), [<img src="https://img.shields.io/pypi/v/yowasp-nextpnr-nexus?label=yowasp-nextpnr-nexus&color=green" alt="yowasp-nextpnr-nexus" class="badge">](https://pypi.org/project/yowasp-nextpnr-nexus/), [<img src="https://img.shields.io/pypi/v/yowasp-nextpnr-gowin?label=yowasp-nextpnr-gowin&color=green" alt="yowasp-nextpnr-gowin" class="badge">](https://pypi.org/project/yowasp-nextpnr-gowin/).
 
-[yosys]: http://www.clifford.at/yosys
+[yosys]: https://yosyshq.net/yosys/
 [nextpnr]: https://github.com/YosysHQ/nextpnr/
 [icestorm]: https://github.com/YosysHQ/icestorm/
 [trellis]: https://github.com/YosysHQ/prjtrellis/


### PR DESCRIPTION
Old Yosys site has some weird gambling ads, so switch to current one.
cc: @clairexen